### PR TITLE
mm-audio: aenc-*: Remove unnecessary `using namespace std;`

### DIFF
--- a/mm-audio/aenc-aac/qdsp6/inc/Map.h
+++ b/mm-audio/aenc-aac/qdsp6/inc/Map.h
@@ -29,7 +29,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _MAP_H_
 
 #include <stdio.h>
-using namespace std;
 
 template <typename T,typename T2>
 class Map

--- a/mm-audio/aenc-aac/qdsp6/src/omx_aac_aenc.cpp
+++ b/mm-audio/aenc-aac/qdsp6/src/omx_aac_aenc.cpp
@@ -41,8 +41,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "omx_aac_aenc.h"
 #include <errno.h>
 
-using namespace std;
-
 #define SLEEP_MS 100
 
 static const OMX_U32 supported_profiles[] = {

--- a/mm-audio/aenc-amrnb/qdsp6/inc/Map.h
+++ b/mm-audio/aenc-amrnb/qdsp6/inc/Map.h
@@ -29,7 +29,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _MAP_H_
 
 #include <stdio.h>
-using namespace std;
 
 template <typename T,typename T2>
 class Map

--- a/mm-audio/aenc-amrnb/qdsp6/src/omx_amr_aenc.cpp
+++ b/mm-audio/aenc-amrnb/qdsp6/src/omx_amr_aenc.cpp
@@ -41,7 +41,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "omx_amr_aenc.h"
 #include <errno.h>
 
-using namespace std;
 #define SLEEP_MS 100
 
 // omx_cmd_queue destructor

--- a/mm-audio/aenc-evrc/qdsp6/inc/Map.h
+++ b/mm-audio/aenc-evrc/qdsp6/inc/Map.h
@@ -29,7 +29,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _MAP_H_
 
 #include <stdio.h>
-using namespace std;
 
 template <typename T,typename T2>
 class Map

--- a/mm-audio/aenc-evrc/qdsp6/src/omx_evrc_aenc.cpp
+++ b/mm-audio/aenc-evrc/qdsp6/src/omx_evrc_aenc.cpp
@@ -41,7 +41,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "omx_evrc_aenc.h"
 #include <errno.h>
 
-using namespace std;
 #define SLEEP_MS 100
 
 // omx_cmd_queue destructor

--- a/mm-audio/aenc-g711/qdsp6/inc/Map.h
+++ b/mm-audio/aenc-g711/qdsp6/inc/Map.h
@@ -30,7 +30,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _MAP_H_
 
 #include <stdio.h>
-using namespace std;
 
 template <typename T,typename T2>
 class Map

--- a/mm-audio/aenc-g711/qdsp6/inc/omx_log.h
+++ b/mm-audio/aenc-g711/qdsp6/inc/omx_log.h
@@ -32,8 +32,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <inttypes.h>
 
-using namespace std;
-
 /*
  * Change logging-level at runtime with "persist.vendor.audio.debug.omx.logs.level"
  *

--- a/mm-audio/aenc-g711/qdsp6/src/omx_g711_aenc.cpp
+++ b/mm-audio/aenc-g711/qdsp6/src/omx_g711_aenc.cpp
@@ -43,7 +43,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "omx_log.h"
 #include <errno.h>
 
-using namespace std;
 #define SLEEP_MS 100
 
 // omx_cmd_queue destructor

--- a/mm-audio/aenc-g711/qdsp6/src/omx_log.cpp
+++ b/mm-audio/aenc-g711/qdsp6/src/omx_log.cpp
@@ -33,8 +33,6 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "omx_log.h"
 
-using namespace std;
-
 uint32_t gOmxLogLevel;
 
 void updateLogLevel() {

--- a/mm-audio/aenc-qcelp13/qdsp6/inc/Map.h
+++ b/mm-audio/aenc-qcelp13/qdsp6/inc/Map.h
@@ -29,7 +29,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _MAP_H_
 
 #include <stdio.h>
-using namespace std;
 
 template <typename T,typename T2>
 class Map

--- a/mm-audio/aenc-qcelp13/qdsp6/src/omx_qcelp13_aenc.cpp
+++ b/mm-audio/aenc-qcelp13/qdsp6/src/omx_qcelp13_aenc.cpp
@@ -41,7 +41,6 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "omx_qcelp13_aenc.h"
 #include <errno.h>
 
-using namespace std;
 #define SLEEP_MS 100
 
 // omx_cmd_queue destructor


### PR DESCRIPTION
Change-Id: I5a60f9bcc2e99c4eeec5d80a372a04131fcf78f4